### PR TITLE
support assets_prefix, setting expiry and content type

### DIFF
--- a/lib/s3_asset_sync/version.rb
+++ b/lib/s3_asset_sync/version.rb
@@ -1,3 +1,3 @@
 module S3AssetSync
-  VERSION = "0.1.3"
+  VERSION = "0.2.0"
 end


### PR DESCRIPTION
These changes made the gem useful for me:
- during upload set the content-type. Without it for example Internet Explorer (9,10) will report `type mismatch`, treat a CSS file as text and not apply any styling. This relies on `Mime::Type` which is part of Rails 4 so no need to list that as dependency.
- during upload set a 1 year expiry. The code is backported from the `asset_sync` gem.
- observe the `config.assets.prefix`, which defaults to `/assets` on new Rails 4 installations. This means on S3 all keys are prefixed with `assets/` (or in other words all files go into the subfolder `assets` in the S3 bucket). It even works with `/` though I would not recommend ever using that (all kinds of side-effects in Rails including loosing session cookies).
